### PR TITLE
Improve test time

### DIFF
--- a/src/test/java/com/sparklicorn/bucket/util/FilesTest.java
+++ b/src/test/java/com/sparklicorn/bucket/util/FilesTest.java
@@ -19,15 +19,6 @@ public class FilesTest {
     }
 
     @Test
-    public void readString_whenInputStreamIsClosed_throwsIOException() {
-        assertThrows(IOException.class, () -> {
-            InputStream in = System.in;
-            in.close();
-            Files.readString(in);
-        });
-    }
-
-    @Test
     public void readString_returnsAllContentInTheStream() {
         String expected = "This is all the content in the input stream";
         InputStream in = new ByteArrayInputStream(expected.getBytes());

--- a/src/test/java/com/sparklicorn/bucket/util/TestPriorityQueue.java
+++ b/src/test/java/com/sparklicorn/bucket/util/TestPriorityQueue.java
@@ -33,7 +33,7 @@ public class TestPriorityQueue {
     }
 
     private static final int SMALL_SIZE = 100;
-    private static final int LARGE_SIZE = 1000000;
+    private static final int LARGE_SIZE = 100_000;
 
     private static ThreadLocalRandom rand = ThreadLocalRandom.current();
 


### PR DESCRIPTION
Resolves #17, #18 

Identified the slow/hanging Files Test, saw it wasn't providing much value, and removed it.

For PriorityQueue slowness, I lowered the number of items in the "large queue" tests an order of magnitude, since the testing time seemed to be directly related to it.

Results from PR checks:
```
[INFO] --- maven-surefire-plugin:3.0.0-M4:test (default-test) @ bucket ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.sparklicorn.bucket.games.sudoku.game.TestBoard
[INFO] Tests run: 78, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.752 s - in com.sparklicorn.bucket.games.sudoku.game.TestBoard
[INFO] Running com.sparklicorn.bucket.games.sudoku.game.solvers.TestSolver
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.117 s - in com.sparklicorn.bucket.games.sudoku.game.solvers.TestSolver
[INFO] Running com.sparklicorn.bucket.util.FilesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.sparklicorn.bucket.util.FilesTest
[INFO] Running com.sparklicorn.bucket.util.TestCounting
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.sparklicorn.bucket.util.TestCounting
[INFO] Running com.sparklicorn.bucket.util.TestStats
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 s - in com.sparklicorn.bucket.util.TestStats
[INFO] Running com.sparklicorn.bucket.util.TestPriorityQueue
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.363 s - in com.sparklicorn.bucket.util.TestPriorityQueue
[INFO] Running com.sparklicorn.bucket.util.event.TestEvent
[INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in com.sparklicorn.bucket.util.event.TestEvent
[INFO] Running com.sparklicorn.bucket.util.TestMath
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.sparklicorn.bucket.util.TestMath
[INFO] Running com.sparklicorn.bucket.util.TestFraction
Testing default values are properly set.
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.sparklicorn.bucket.util.TestFraction
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 158, Failures: 0, Errors: 0, Skipped: 0
```