### PR TITLE
Fix package publishing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -4,16 +4,16 @@ on:
     branches: ['release']
 jobs:
   publish:
-    runs-on: ubuntu-latest 
-    permissions: 
+    runs-on: ubuntu-latest
+    permissions:
       contents: read
-      packages: write 
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Publish package
         run: mvn --batch-mode deploy
         env:


### PR DESCRIPTION
Trial and error: Thinking it's the distribution.
GitHub action doc mentions adopt moved to temurin and won't be updated. ([source](https://github.com/actions/setup-java#supported-distributions))

If this update doesn't work, next try modifying the maven command in some way. There's a discussions thread detailing how Maven 3.9.0 is broken, and includes proposed workarounds.