### PR TITLE
Change publish workflow to activate on version tag push

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,7 +1,7 @@
 name: Publish package to GitHub Packages
 on:
   push:
-    branches: ['release']
+    tags: ['v**']
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`v**` tags, which are protected by repo, will trigger the publish package workflow.