### PR TITLE
Revert: Only publish package when tagged on main

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,7 +1,6 @@
 name: Publish package to GitHub Packages
 on:
   push:
-    branches: ['main']
     tags: ['v**']
 jobs:
   publish:


### PR DESCRIPTION
It doesn't seem possible to only trigger workflow when pushing tag on a specific branch. That's not how tags work.