### PR TITLE
Backfill searchqueue tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.sparklicorn.bucket</groupId>
   <artifactId>bucket</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <packaging>jar</packaging>
 
   <name>Bucket</name>

--- a/src/main/java/com/sparklicorn/bucket/util/PriorityQueue.java
+++ b/src/main/java/com/sparklicorn/bucket/util/PriorityQueue.java
@@ -101,19 +101,29 @@ public class PriorityQueue<T extends Comparable<T>> extends AbstractQueue<T> {
 	}
 
 	@Override public T poll() {
-		T result = null;
-		if (!heap.isEmpty()) {
-			result = heap.get(0);
-			heap.set(0, heap.get(heap.size() - 1));
-			heap.remove(heap.size() - 1);
-			if (heap.size() > 1) {
-				propogateDown(0);
-			}
+		if (isEmpty()) {
+			return null;
 		}
+
+		T result = heap.get(0);
+		heap.set(0, heap.get(size() - 1));
+		heap.remove(size() - 1);
+		if (size() > 1) {
+			propogateDown(0);
+		}
+
 		return result;
 	}
 
-	@Override public T peek() { return heap.get(0); }
-	@Override public Iterator<T> iterator() { return heap.iterator(); }
-	@Override public int size() { return heap.size(); }
+	@Override public T peek() {
+		return isEmpty() ? null : heap.get(0);
+	}
+
+	@Override public Iterator<T> iterator() {
+		return heap.iterator();
+	}
+
+	@Override public int size() {
+		return heap.size();
+	}
 }

--- a/src/main/java/com/sparklicorn/bucket/util/SearchQueue.java
+++ b/src/main/java/com/sparklicorn/bucket/util/SearchQueue.java
@@ -47,12 +47,12 @@ public class SearchQueue<T> extends AbstractQueue<T> {
 
     @Override
     public T poll() {
-        return queue.removeFirst();
+        return isEmpty() ? null : queue.removeFirst();
     }
 
     @Override
     public T peek() {
-        return queue.getFirst();
+        return isEmpty() ? null : queue.getFirst();
     }
 
     @Override

--- a/src/main/java/com/sparklicorn/bucket/util/Shuffler.java
+++ b/src/main/java/com/sparklicorn/bucket/util/Shuffler.java
@@ -1,13 +1,81 @@
 package com.sparklicorn.bucket.util;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 import java.util.random.RandomGenerator;
 
 /**
  * A Shuffle utility that implements a version of the Fisher-Yates shuffling algorithm.
  */
 public final class Shuffler {
+
+	/**
+	 * Returns a list of ints in the range [0, to) (Note, `to` is exclusive).
+	 */
+	public static List<Integer> range(int to) {
+		return rangeFiltered(0, to, (n) -> true);
+	}
+
+	/**
+	 * Returns a list of ints in the range [0, to) that are accepted by the filter function.
+	 */
+	public static List<Integer> rangeFiltered(int from, int to, Function<Integer,Boolean> filter) {
+		List<Integer> result = new ArrayList<>();
+		for (int n = from; n < to; n++) {
+			if (filter.apply(n)) {
+				result.add(n);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns a Set of random ints with the given size.
+	 */
+	public static Set<Integer> randomSet(int size) {
+		return randomSet(new HashSet<>(), size, Integer.MIN_VALUE, Integer.MAX_VALUE, (n) -> true);
+	}
+
+	/*
+	 * Returns a Set with the given size, containing random ints from interval [origin, bound).
+	 */
+	public static Set<Integer> randomSet(int size, int origin, int bound) {
+		return randomSet(new HashSet<>(), size, origin, bound, (n) -> true);
+	}
+
+	/*
+	 * Returns a Set with the given size, containing random ints from interval [origin, bound)
+	 * that are accepted by the filter function.
+	 */
+	public static Set<Integer> randomSet(int size, int origin, int bound, Function<Integer, Boolean> filter) {
+		return randomSet(new HashSet<>(), size, origin, bound, filter);
+	}
+
+	/**
+	 * Clears the given Set, then repopulates it with random ints from the interval [origin, bound)
+	 * that are accepted by the filter function.
+	 *
+	 * @return The given set.
+	 */
+	public static Set<Integer> randomSet(Set<Integer> set, int size, int origin, int bound, Function<Integer, Boolean> filter) {
+		if ((long)size > (long)bound - (long)origin) {
+			throw new IllegalArgumentException("Requested size exceeds number of possibilities.");
+		}
+
+		ThreadLocalRandom generator = ThreadLocalRandom.current();
+		set.clear();
+		while (set.size() < size) {
+			int rand = generator.nextInt(origin, bound);
+			if (filter.apply(rand)) {
+				set.add(rand);
+			}
+		}
+		return set;
+	}
 
 	public static int[] random(int[] arr) {
 		return random(arr, 0, Integer.MAX_VALUE);

--- a/src/test/java/com/sparklicorn/bucket/util/TestPriorityQueue.java
+++ b/src/test/java/com/sparklicorn/bucket/util/TestPriorityQueue.java
@@ -1,10 +1,10 @@
 package com.sparklicorn.bucket.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.PriorityQueue;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +71,8 @@ public class TestPriorityQueue {
 
         assertEquals(0, pq.size());
         assertTrue(pq.isEmpty());
+        assertNull(pq.peek());
+        assertNull(pq.poll());
 
         print("Offering to queue... ");
         for (int i = 0; i < size; i++) {

--- a/src/test/java/com/sparklicorn/bucket/util/TestPrioritySearchQueue.java
+++ b/src/test/java/com/sparklicorn/bucket/util/TestPrioritySearchQueue.java
@@ -1,0 +1,200 @@
+package com.sparklicorn.bucket.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestPrioritySearchQueue {
+    private static final int SMALL_SIZE = 100;
+    private static final int LARGE_SIZE = 10_000;
+
+    private static final boolean DEBUG_OUTPUT = false;
+
+    private static void print(String msg) {
+        if (DEBUG_OUTPUT) {
+            System.out.print(msg);
+        }
+    }
+
+    private static void println(String msg) {
+        if (DEBUG_OUTPUT) {
+            System.out.println(msg);
+        }
+    }
+
+    private static void printf(String format, Object... args) {
+        if (DEBUG_OUTPUT) {
+            System.out.printf(format, args);
+        }
+    }
+
+    PrioritySearchQueue<Integer> queue;
+
+    @BeforeAll
+    private static void beforeAll() {
+        println("TestPrioritySearchQueue");
+    }
+
+    @BeforeEach
+    private void before() {
+        queue = new PrioritySearchQueue<>();
+    }
+
+    private void test(List<Integer> offered, List<Integer> expectedInOrder) {
+        int expectedSize = 0;
+        Set<Integer> seen = new HashSet<>();
+
+        print("When the queue is empty... ");
+        assertTrue(queue.isEmpty());
+        assertEquals(expectedSize, queue.size());
+        assertEquals(seen.size(), queue.seenSize());
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+        assertFalse(queue.seenIterator().hasNext());
+        println("Done.");
+
+        print("When items are offered to the queue... ");
+        for (int n : offered) {
+            assertEquals(expectedSize, queue.size());
+            assertEquals(seen.size(), queue.seenSize());
+            assertEquals(seen.contains(n), queue.contains(n));
+
+            if (!seen.contains(n) && expectedInOrder.contains(n)) {
+                assertTrue(queue.canAccept(n));
+                assertTrue(queue.offer(n));
+                expectedSize++;
+                seen.add(n);
+                assertTrue(queue.hasSeen(n));
+                assertEquals(expectedSize, queue.size());
+                assertEquals(seen.size(), queue.seenSize());
+            }
+
+            assertFalse(queue.canAccept(n));
+            assertFalse(queue.offer(n));
+            assertEquals(seen.size(), queue.seenSize());
+            assertEquals(expectedSize, queue.size());
+        }
+        println("Done.");
+
+        print("When items are polled from the queue... ");
+        for (int n : expectedInOrder) {
+            assertTrue(queue.hasSeen(n));
+            assertEquals(n, queue.peek());
+            assertEquals(expectedSize, queue.size());
+            assertEquals(seen.size(), queue.seenSize());
+
+            assertEquals(n, queue.poll());
+            expectedSize--;
+            assertEquals(expectedSize, queue.size());
+            assertEquals(seen.size(), queue.seenSize());
+
+            assertTrue(queue.hasSeen(n));
+            assertFalse(queue.offer(n));
+            assertEquals(expectedSize, queue.size());
+            assertEquals(seen.size(), queue.seenSize());
+        }
+        println("Done.");
+
+        print("When no more items remain in the queue... ");
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+        assertTrue(queue.seenIterator().hasNext());
+        println("Done.");
+    }
+
+    private List<Integer> duplicateRandomElements(Collection<Integer> collection, float duplicationRate, int passes) {
+        if (collection.isEmpty()) {
+            throw new IllegalArgumentException("Given collection may not be empty");
+        }
+        if (duplicationRate < 0f || duplicationRate > 1f) {
+            throw new IllegalArgumentException("Duplication rate must be in [0,1]");
+        }
+
+        List<Integer> result = new ArrayList<>(collection);
+        ThreadLocalRandom generator = ThreadLocalRandom.current();
+
+        for (int pass = 0; pass < passes; pass++) {
+            for (Integer e : collection) {
+                if (generator.nextFloat() <= duplicationRate) {
+                    result.add(e);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private List<Integer> sortSet(Set<Integer> set) {
+        List<Integer> result = new ArrayList<>(set);
+        result.sort((a, b) -> Integer.compare(a, b));
+        return result;
+    }
+
+    private void test(int size, Function<Integer, Boolean> acceptanceCriteria) {
+        printf("test(size = %d)\n", size);
+        if (acceptanceCriteria != null) {
+            queue = new PrioritySearchQueue<>(acceptanceCriteria);
+            println("acceptanceCriteria set");
+        }
+
+        print("Generating random set... ");
+        Set<Integer> randomSet = Shuffler.randomSet(
+            size,
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE,
+            (n) -> (acceptanceCriteria == null ? true : acceptanceCriteria.apply(n))
+        );
+        println("Done.");
+
+        print("Sorting set as list... ");
+        List<Integer> expectedInOrder = sortSet(randomSet);
+        println("Done.");
+
+        print("Duplicating random items in list... ");
+        List<Integer> offered = duplicateRandomElements(expectedInOrder, 0.25f, 4);
+        println("Done.");
+
+        print("Shuffling list... ");
+        Shuffler.shuffleList(offered);
+        println("Done.");
+
+        println("Testing queue... ");
+        test(offered, expectedInOrder);
+        println("Test complete.");
+    }
+
+    @Test
+    public void testWithoutAcceptanceCriteria_small() {
+        test(SMALL_SIZE, null);
+    }
+
+    @Test
+    public void testWithoutAcceptanceCriteria_large() {
+        test(LARGE_SIZE, null);
+    }
+
+    @Test
+    public void test_small() {
+        test(SMALL_SIZE, (n) -> n % 2 == 0);
+    }
+
+    @Test
+    public void test_large() {
+        test(LARGE_SIZE, (n) -> n % 2 == 0);
+    }
+}

--- a/src/test/java/com/sparklicorn/bucket/util/TestSearchQueue.java
+++ b/src/test/java/com/sparklicorn/bucket/util/TestSearchQueue.java
@@ -1,0 +1,142 @@
+package com.sparklicorn.bucket.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestSearchQueue {
+    private SearchQueue<Integer> queue;
+
+    private final Function<Integer,Boolean> EVENS_ONLY = (n) -> n % 2 == 0;
+
+    @BeforeEach
+    public void setup() {
+        queue = new SearchQueue<>();
+    }
+
+    @Test
+    public void test() {
+        // When acceptance criteria is not set
+        // When item is not yet seen
+        int expectedSize = 0;
+        int expectedSeenSize = 0;
+
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+        assertFalse(queue.seenIterator().hasNext());
+
+        for (int n = -100; n < 100; n++) {
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+            assertFalse(queue.hasSeen(n));
+            assertTrue(queue.canAccept(n));
+            assertTrue(queue.offer(n));
+            expectedSize++;
+            expectedSeenSize++;
+            assertFalse(queue.canAccept(n));
+            assertTrue(queue.hasSeen(n));
+            assertFalse(queue.offer(n));
+            assertEquals(expectedSeenSize, queue.seenSize());
+            assertEquals(expectedSize, queue.size());
+        }
+
+        for (int n = -100; n < 100; n++) {
+            assertTrue(queue.hasSeen(n));
+            assertEquals(n, queue.peek());
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+
+            assertEquals(n, queue.poll());
+            expectedSize--;
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+
+            assertTrue(queue.hasSeen(n));
+            assertFalse(queue.offer(n));
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+        }
+
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+        assertTrue(queue.seenIterator().hasNext());
+
+        // When acceptance criteria is set
+        queue = new SearchQueue<>(EVENS_ONLY);
+        expectedSize = 0;
+        expectedSeenSize = 0;
+
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertFalse(queue.iterator().hasNext());
+        assertFalse(queue.seenIterator().hasNext());
+
+        for (int n = -100; n < 100; n++) {
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+            assertFalse(queue.hasSeen(n));
+            if (n % 2 == 0) {
+                assertTrue(queue.canAccept(n));
+                assertTrue(queue.offer(n));
+                expectedSize++;
+                expectedSeenSize++;
+                assertTrue(queue.hasSeen(n));
+                assertEquals(expectedSize, queue.size());
+                assertEquals(expectedSeenSize, queue.seenSize());
+            } else {
+                assertFalse(queue.canAccept(n));
+                assertFalse(queue.offer(n));
+            }
+            assertFalse(queue.canAccept(n));
+            assertFalse(queue.offer(n));
+            assertEquals(expectedSeenSize, queue.seenSize());
+            assertEquals(expectedSize, queue.size());
+        }
+
+        for (int n = -100; n < 100; n++) {
+            if (n % 2 == 0) {
+                assertTrue(queue.iterator().hasNext());
+                assertTrue(queue.hasSeen(n));
+                assertEquals(n, queue.peek());
+                assertEquals(expectedSize, queue.size());
+                assertEquals(expectedSeenSize, queue.seenSize());
+                assertEquals(n, queue.poll());
+                expectedSize--;
+                assertEquals(expectedSize, queue.size());
+                assertEquals(expectedSeenSize, queue.seenSize());
+            } else {
+                assertFalse(queue.hasSeen(n));
+                if (n == 99) {
+                    assertNull(queue.peek());
+                    assertNull(queue.poll());
+                } else {
+                    assertFalse(n == queue.peek());
+                }
+                assertEquals(expectedSize, queue.size());
+                assertEquals(expectedSeenSize, queue.seenSize());
+            }
+
+            assertFalse(queue.offer(n));
+            assertFalse(queue.canAccept(n));
+            assertEquals(expectedSize, queue.size());
+            assertEquals(expectedSeenSize, queue.seenSize());
+        }
+
+        assertNull(queue.peek());
+        assertNull(queue.poll());
+        assertEquals(expectedSize, queue.size());
+        assertEquals(expectedSeenSize, queue.seenSize());
+        assertFalse(queue.iterator().hasNext());
+        assertTrue(queue.seenIterator().hasNext());
+        assertEquals(expectedSize, queue.size());
+        assertEquals(expectedSeenSize, queue.seenSize());
+    }
+}


### PR DESCRIPTION
Resolves #50

Found a few defects while doing this:
 - `TestPriorityQueue` was actually testing `java.util.PriorityQueue` (which I forgot even existed) instead of our PQ.
 - After the above was corrected, it was found that `priorityQueue.peek()` and `prioritySearchQueue.peek()` throw `IndexOutOfBoundsException` when the queue is empty. They now properly return null.
   - Same for `searchQueue.peek() and poll()`.

Some utility functions were added to `Shuffler` to help generate ranges and random sets. The sets were used in `TestPrioritySearchQueue`.
