### PR TITLE
Patch package publish workflow (2)

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -15,6 +15,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Publish package
-        run: ./mvnw -B clean deploy
+        run: |
+          SUBMODULE=$(echo "$TAG_NAME" | cut -d '-' -f 2)
+          if [ -n "$SUBMODULE" ]; then
+            echo "Deploying submodule $SUBMODULE"
+            ./mvnw -B deploy -pl "$SUBMODULE"
+          else
+            echo "Deploying all modules"
+            ./mvnw -B deploy
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
Maven deploy returns `409 - Conflict` error when attempting to deploy artifacts that already exist.
When only a subset of modules needs to be deployed, use `mvn -B clean install deploy -pl MODULE_NAME` to build, test, then deploy a single module.

Tags should follow the convention:
- `v#.#.#` for deploying everything, or
- `v#.#.#-module` for deploying a single module.

Note that the module name in the action is taken as the second part of the tag name, as delimited by `-`. The deployment will fail if this second part is not a valid module name.
For patch release tags, I recommend when deploying everything to use `v#.#.#--#`, then the `cut -d '-' -f 2` will return empty. For deploying patch for specific module, just append `-#`.