### PR TITLE
Bump v1.0.1 for pom changes

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -25,5 +25,4 @@ jobs:
             ./mvnw -B deploy
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}

--- a/bucket/pom.xml
+++ b/bucket/pom.xml
@@ -4,11 +4,23 @@
   <parent>
     <artifactId>root</artifactId>
     <groupId>com.sparklicorn.bucket</groupId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Bucket</name>
   <groupId>com.sparklicorn.bucket</groupId>
   <artifactId>bucket</artifactId>
-  <version>1.4.1</version>
+  <version>${bucket.version}</version>
+
+  <properties>
+    <gson>2.10.1</gson>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>1.0.0</revision>
-    <bucket.version>1.4.1</bucket.version>
-    <sudoku.version>1.0.0</sudoku.version>
-    <tetris.version>1.0.1</tetris.version>
+    <revision>1.0.1</revision>
+    <bucket.version>1.4.2</bucket.version>
+    <sudoku.version>1.0.1</sudoku.version>
+    <tetris.version>1.0.2</tetris.version>
 
     <!-- Environment -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,15 @@
 
   <groupId>com.sparklicorn.bucket</groupId>
   <artifactId>root</artifactId>
-  <version>1.0.0</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <properties>
+    <revision>1.0.0</revision>
+    <bucket.version>1.4.1</bucket.version>
+    <sudoku.version>1.0.0</sudoku.version>
+    <tetris.version>1.0.1</tetris.version>
+
     <!-- Environment -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
@@ -19,22 +24,16 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
 
     <!-- Dependency versions -->
-    <gson>2.10.1</gson>
     <junit>5.6.2</junit>
 
     <!-- Plugin versions -->
     <maven.surefire>3.0.0</maven.surefire>
     <maven.shade>3.4.1</maven.shade>
     <maven.source>3.2.1</maven.source>
+    <spring.boot.maven.plugin>3.2.1</spring.boot.maven.plugin>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>${gson}</version>
-    </dependency>
-
     <!-- Testing dependencies-->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/sudoku/pom-exe.xml
+++ b/sudoku/pom-exe.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>root</artifactId>
     <groupId>com.sparklicorn.bucket</groupId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Sudoku</name>
@@ -16,7 +16,7 @@
     <dependency>
       <artifactId>bucket</artifactId>
       <groupId>com.sparklicorn.bucket</groupId>
-      <version>1.4.1</version>
+      <version>${bucket.version}</version>
     </dependency>
   </dependencies>
 
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.0.5</version>
+        <version>${spring.boot.maven.plugin}</version>
         <executions>
           <execution>
             <goals>

--- a/sudoku/pom.xml
+++ b/sudoku/pom.xml
@@ -4,19 +4,19 @@
   <parent>
     <artifactId>root</artifactId>
     <groupId>com.sparklicorn.bucket</groupId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Sudoku</name>
   <groupId>com.sparklicorn.bucket</groupId>
   <artifactId>sudoku</artifactId>
-  <version>1.0.0</version>
+  <version>${sudoku.version}</version>
 
   <dependencies>
     <dependency>
       <artifactId>bucket</artifactId>
       <groupId>com.sparklicorn.bucket</groupId>
-      <version>1.4.1</version>
+      <version>${bucket.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/tetris/pom-exe.xml
+++ b/tetris/pom-exe.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>root</artifactId>
     <groupId>com.sparklicorn.bucket</groupId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Tetris</name>
@@ -17,7 +17,7 @@
     <dependency>
       <artifactId>bucket</artifactId>
       <groupId>com.sparklicorn.bucket</groupId>
-      <version>1.4.1</version>
+      <version>${bucket.version}</version>
     </dependency>
   </dependencies>
 
@@ -26,7 +26,7 @@
         <plugin>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
-            <version>3.0.5</version>
+            <version>${spring.boot.maven.plugin}</version>
             <executions>
                 <execution>
                     <goals>

--- a/tetris/pom.xml
+++ b/tetris/pom.xml
@@ -4,19 +4,19 @@
   <parent>
     <artifactId>root</artifactId>
     <groupId>com.sparklicorn.bucket</groupId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
   </parent>
 
   <name>Tetris</name>
   <groupId>com.sparklicorn.bucket</groupId>
   <artifactId>tetris</artifactId>
-  <version>1.0.1</version>
+  <version>${tetris.version}</version>
 
   <dependencies>
     <dependency>
       <artifactId>bucket</artifactId>
       <groupId>com.sparklicorn.bucket</groupId>
-      <version>1.4.1</version>
+      <version>${bucket.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/tetris/src/main/java/com/sparklicorn/bucket/tetris/util/structs/ShapeQueue.java
+++ b/tetris/src/main/java/com/sparklicorn/bucket/tetris/util/structs/ShapeQueue.java
@@ -18,8 +18,7 @@ import com.sparklicorn.bucket.util.Shuffler;
 public class ShapeQueue implements Queue<Shape> {
 	public static final int DEFAULT_MIN_SIZE = 14;
 
-	protected static final List<Integer> SHAPES = Shuffler.range(1, Shape.NUM_SHAPES + 1);
-
+	protected final List<Integer> SHAPES = Shuffler.range(1, Shape.NUM_SHAPES + 1);
 	protected final int minSize;
 	protected final LinkedList<Integer> shapeIndexQueue;
 


### PR DESCRIPTION
Updated poms to maintain module versioning via parent pom.

Bumped module versions:
v1.4.2-bucket
v1.0.1-sudoku
v1.0.2-tetris

Other changes:
Moved `gson` dep to `bucket` since it's not used anywhere else.
Fixed issue with `ShapeQueue`.
Removed custom token in publish package workflow. Will try using default GITHUB_TOKEN on secret context and giving it r/w perms in repo settings.
