### PR TITLE
Fix issue where tetris runner breaks when 'run' key is held down

### DIFF
--- a/tetris-ai/src/main/java/com/sparklicorn/tetrisai/drivers/DefaultTetrisRunner.java
+++ b/tetris-ai/src/main/java/com/sparklicorn/tetrisai/drivers/DefaultTetrisRunner.java
@@ -6,7 +6,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.util.concurrent.Future;
 
 import javax.swing.BorderFactory;
 import javax.swing.JFrame;
@@ -108,11 +107,10 @@ public class DefaultTetrisRunner extends JFrame implements KeyListener {
 			tetris.newGame();
 			tetris.start(0);
 		} else if (e.getKeyCode() == KeyEvent.VK_G) {
-			asyncRunGame(tetris, 1, false);
+			runGame(0L, false);
 		} else if (e.getKeyCode() == KeyEvent.VK_H) {
-			asyncRunGame(tetris, 1, true);
+			runGame(0L, true);
 		} else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
-			tetris.shutdown();
 			dispose();
 		}
 	}
@@ -134,10 +132,13 @@ public class DefaultTetrisRunner extends JFrame implements KeyListener {
 	}
 
 	public GameStats runGame(long sleepTime, boolean useLookAhead) {
-		return tetris.run(sleepTime, useLookAhead);
-	}
-
-	public static Future<GameStats> asyncRunGame(AiTetris g1, long sleepTime, boolean useLookAhead) {
-		return ThreadPool.submit(() -> g1.run(sleepTime, useLookAhead));
+		try {
+			if (!tetris.isRunning()) {
+				return tetris.run(sleepTime, useLookAhead);
+			}
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+		return null;
 	}
 }

--- a/tetris-ai/src/main/java/com/sparklicorn/tetrisai/game/AiTetris.java
+++ b/tetris-ai/src/main/java/com/sparklicorn/tetrisai/game/AiTetris.java
@@ -94,7 +94,7 @@ public class AiTetris extends TetrisGame {
 			0,
 			this.state.shape.getNumRotations()
 		);
-		populateBlockPositions(state.blockLocations, state.position);
+		state.updateBlockPositions();
 	}
 
 	/**
@@ -225,7 +225,9 @@ public class AiTetris extends TetrisGame {
 			while (!state.isGameOver) {
 				if (state.isActive) {
 					state.position = findBestPlacement(getState(), ranker, options);
-					populateBlockPositions(state.blockLocations, state.position);
+					if (state.position != null) {
+						state.updateBlockPositions();
+					}
 				}
 
 				// System.out.print('.');
@@ -267,7 +269,7 @@ public class AiTetris extends TetrisGame {
 		if (!state.isGameOver && state.isActive) {
 			LookAheadOptions options = new LookAheadOptions(useLookAhead ? 3 : 0, 0.25f);
 			state.position = findBestPlacement(getState(), ranker, options);
-			populateBlockPositions(state.blockLocations, state.position);
+			state.updateBlockPositions();
 		}
 	}
 
@@ -360,7 +362,7 @@ public class AiTetris extends TetrisGame {
 	 *
 	 * @param lookAhead - Whether to consider the next shape when calculating.
 	 */
-	public Position findBestPlacement(
+	public static Position findBestPlacement(
 		TetrisState state,
 		ITetrisStateRanker ranker,
 		LookAheadOptions options

--- a/tetris/src/main/java/com/sparklicorn/bucket/tetris/TetrisGame.java
+++ b/tetris/src/main/java/com/sparklicorn/bucket/tetris/TetrisGame.java
@@ -108,6 +108,13 @@ public class TetrisGame implements ITetrisGame {
 	}
 
 	/**
+	 * Returns whether the game is currently running.
+	 */
+	public boolean isRunning() {
+		return state.hasStarted && !state.isGameOver;
+	}
+
+	/**
 	 * Returns points rewarded for clearing lines at a given level.
 	 *
 	 * @param lines Number of lines cleared.
@@ -116,25 +123,6 @@ public class TetrisGame implements ITetrisGame {
 	 */
 	protected long calcPointsForClearing(int lines) {
 		return POINTS_BY_LINES_CLEARED.get(lines) * (state.level + 1L);
-	}
-
-	/**
-	 * Calculates the coordinates of blocks that make up the current shape,
-	 * in the given position.
-	 *
-	 * @param coords Contains block coordinates that make up the shape.
-	 * The newly calculated block positions will be written here.
-	 * @param pos The location and rotation of the shape to calculate block positions for.
-	 * @return The modified blockCoords array (for convenience).
-	 */
-	public Coord[] populateBlockPositions(Coord[] coords, Position pos) {
-		int rotationIndex = state.shape.rotationIndex(pos.rotation());
-		for (int i = 0; i < coords.length; i++) {
-			coords[i].set(pos.offset());
-			coords[i].add(state.shape.rotationOffsets[rotationIndex][i]);
-		}
-
-		return coords;
 	}
 
 	public Coord[] populateBlockPositions(Position move) {


### PR DESCRIPTION
Fixes #94 

- (Main defect) Removed `DefaultTetrisRunner#asyncRunGame`. Games should run serially as multiple threads acting on a single game instance concurrently is not supported and may cause problems.
- Changed `sleepTime` -> `0L` since any positive value causes the swing event handler thread to sleep and results in UI slog.
- Removed unused `populateBlockPositions`
- Added `TetrisGame#isRunning`